### PR TITLE
Bugfixes

### DIFF
--- a/Model/Total/CashOnDeliveryFee.php
+++ b/Model/Total/CashOnDeliveryFee.php
@@ -39,6 +39,10 @@ class CashOnDeliveryFee extends AbstractTotal
     ): CashOnDeliveryFee {
         parent::collect($quote, $shippingAssignment, $total);
 
+        if (count($shippingAssignment->getItems()) == 0) {
+            return $this;
+        }
+
         $cashOnDeliveryFee = $this->getFee($quote);
 
         $total->setData(static::TOTAL_CODE, $cashOnDeliveryFee);

--- a/Model/Total/Creditmemo/CashOnDeliveryFee.php
+++ b/Model/Total/Creditmemo/CashOnDeliveryFee.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+
+namespace Brandung\CashOnDeliveryFee\Model\Total\Creditmemo;
+
+class CashOnDeliveryFee extends \Magento\Sales\Model\Order\Creditmemo\Total\AbstractTotal
+{
+    /**
+     * @inheritdoc
+     */
+    public function collect(\Magento\Sales\Model\Order\Creditmemo $creditmemo)
+    {
+        parent::collect($creditmemo);
+
+        $codFee = $creditmemo->getOrder()->getExtensionAttributes()->getCashOnDeliveryFee();
+        $baseCodFee = $creditmemo->getOrder()->getExtensionAttributes()->getBaseCashOnDeliveryFee();
+
+        $creditmemo->setData(\Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee::TOTAL_CODE, $codFee);
+        $creditmemo->setData(\Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee::BASE_TOTAL_CODE, $baseCodFee);
+
+        if (round($codFee, 2) != 0)
+        {
+            $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $codFee);
+            $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $codFee);
+        }
+
+        return $this;
+    }
+}

--- a/Model/Total/Invoice/CashOnDeliveryFee.php
+++ b/Model/Total/Invoice/CashOnDeliveryFee.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+
+namespace Brandung\CashOnDeliveryFee\Model\Total\Invoice;
+
+class CashOnDeliveryFee extends \Magento\Sales\Model\Order\Invoice\Total\AbstractTotal
+{
+    /**
+     * @inheritdoc
+     */
+    public function collect(\Magento\Sales\Model\Order\Invoice $invoice)
+    {
+        parent::collect($invoice);
+
+        $codFee = $invoice->getOrder()->getExtensionAttributes()->getCashOnDeliveryFee();
+        $baseCodFee = $invoice->getOrder()->getExtensionAttributes()->getBaseCashOnDeliveryFee();
+
+        $invoice->setData(\Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee::TOTAL_CODE, $codFee);
+        $invoice->setData(\Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee::BASE_TOTAL_CODE, $baseCodFee);
+
+        if (round($codFee, 2) != 0)
+        {
+            $invoice->setGrandTotal($invoice->getGrandTotal() + $codFee);
+            $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() + $codFee);
+        }
+
+        return $this;
+    }
+}

--- a/Plugin/CheckoutAgreements/Model/AgreementsValidator.php
+++ b/Plugin/CheckoutAgreements/Model/AgreementsValidator.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types = 1);
+namespace Brandung\CashOnDeliveryFee\Plugin\CheckoutAgreements\Model;
+
+class AgreementsValidator
+{
+    private $isSkipValidation = false;
+
+    /**
+     * @see \Magento\CheckoutAgreements\Model\Checkout\Plugin\Validation
+     * @see    \Magento\CheckoutAgreements\Model\AgreementsValidator::isValid
+     * @plugin around
+     * @param \Magento\CheckoutAgreements\Model\AgreementsValidator $subject
+     * @param \Closure $proceed
+     * @param int[] $agreementIds
+     * @return bool
+     */
+    public function aroundIsValid(\Magento\CheckoutAgreements\Model\AgreementsValidator $subject, \Closure $proceed, $agreementIds)
+    {
+        if ($this->isSkipValidation)
+        {
+            return true;
+        }
+        else
+        {
+            return $proceed($agreementIds);
+        }
+    }
+
+    /**
+     * @param bool $isSkipValidation
+     * @return AgreementsValidator
+     */
+    public function setIsSkipValidation(bool $isSkipValidation): AgreementsValidator
+    {
+        $this->isSkipValidation = $isSkipValidation;
+        return $this;
+    }
+}

--- a/Plugin/Payment/Model/ChecksTotalMinMax.php
+++ b/Plugin/Payment/Model/ChecksTotalMinMax.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types = 1);
+namespace Brandung\CashOnDeliveryFee\Plugin\Payment\Model;
+
+use Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee;
+use Magento\OfflinePayments\Model\Cashondelivery;
+use Magento\Payment\Model\MethodInterface;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Cash for delivery max grandtotal limit has to take into account the fee. This is important if the grandtotal is near the limit
+ * and the fee would put it over. On the first visit to checkout, grandtotal will not include the fee so the payment method would
+ * be listed, but after selecting it the grandtotal would go over and the payment method is no longer selectable.
+ */
+class ChecksTotalMinMax
+{
+    /**
+     * @see    \Magento\Payment\Model\Checks\TotalMinMax::isApplicable
+     * @plugin around
+     * @param \Magento\Payment\Model\Checks\TotalMinMax $subject
+     * @param \Closure $proceed
+     * @param MethodInterface $paymentMethod
+     * @param Quote $quote
+     * @return bool
+     */
+    public function aroundIsApplicable(\Magento\Payment\Model\Checks\TotalMinMax $subject,
+                                       \Closure $proceed,
+                                       MethodInterface $paymentMethod,
+                                       Quote $quote)
+    {
+        $quoteTotals = $quote->getTotals();
+
+        if ($paymentMethod->getCode() == Cashondelivery::PAYMENT_METHOD_CASHONDELIVERY_CODE &&
+            isset($quoteTotals[CashOnDeliveryFee::TOTAL_CODE]) &&
+            $quoteTotals[CashOnDeliveryFee::TOTAL_CODE]->getData('value') == 0)
+        {
+            $total = $quote->getGrandTotal() + $paymentMethod->getConfigData('fee');
+            $minTotal = $paymentMethod->getConfigData($subject::MIN_ORDER_TOTAL);
+            $maxTotal = $paymentMethod->getConfigData($subject::MAX_ORDER_TOTAL);
+
+            if (!empty($minTotal) && $total < $minTotal || !empty($maxTotal) && $total > $maxTotal)
+            {
+                return false;
+            }
+            return true;
+        } else
+        {
+            return $proceed($paymentMethod, $quote);
+        }
+    }
+}

--- a/Service/V1/GuestPaymentInformationManagement.php
+++ b/Service/V1/GuestPaymentInformationManagement.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 namespace Brandung\CashOnDeliveryFee\Service\V1;
 
 use Brandung\CashOnDeliveryFee\Api\GuestPaymentInformationManagementInterface;
+use Brandung\CashOnDeliveryFee\Plugin\CheckoutAgreements\Model\AgreementsValidator;
 use Magento\Checkout\Api\GuestPaymentInformationManagementInterface as MagentoGuestPaymentManagementInterface;
 use Magento\Quote\Api\Data\AddressInterface;
 use Magento\Quote\Api\Data\PaymentInterface;
@@ -19,13 +20,19 @@ class GuestPaymentInformationManagement implements GuestPaymentInformationManage
      * @var GuestCartTotalRepositoryInterface
      */
     private $guestCartTotalRepository;
+    /**
+     * @var AgreementsValidator
+     */
+    private $agreementsValidatorSkipPlugin;
 
     public function __construct(
         MagentoGuestPaymentManagementInterface $guestPaymentInformationManagement,
-        GuestCartTotalRepositoryInterface $guestCartTotalRepository
+        GuestCartTotalRepositoryInterface $guestCartTotalRepository,
+        AgreementsValidator $agreementsValidatorSkipPlugin
     ) {
         $this->guestPaymentInformationManagement = $guestPaymentInformationManagement;
         $this->guestCartTotalRepository = $guestCartTotalRepository;
+        $this->agreementsValidatorSkipPlugin = $agreementsValidatorSkipPlugin;
     }
 
     /**
@@ -37,6 +44,8 @@ class GuestPaymentInformationManagement implements GuestPaymentInformationManage
         PaymentInterface $paymentMethod,
         AddressInterface $billingAddress = null
     ): TotalsInterface {
+        $this->agreementsValidatorSkipPlugin->setIsSkipValidation(true);
+
         $this->guestPaymentInformationManagement->savePaymentInformation(
             $cartId,
             $email,

--- a/Service/V1/PaymentInformationManagement.php
+++ b/Service/V1/PaymentInformationManagement.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 namespace Brandung\CashOnDeliveryFee\Service\V1;
 
 use Brandung\CashOnDeliveryFee\Api\PaymentInformationManagementInterface;
+use Brandung\CashOnDeliveryFee\Plugin\CheckoutAgreements\Model\AgreementsValidator;
 use Magento\Checkout\Api\PaymentInformationManagementInterface as MagentoPaymentInformationManagementInterface;
 use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magento\Quote\Api\Data\AddressInterface;
@@ -19,13 +20,19 @@ class PaymentInformationManagement implements PaymentInformationManagementInterf
      * @var CartTotalRepositoryInterface
      */
     private $cartTotalRepository;
+    /**
+     * @var AgreementsValidator
+     */
+    private $agreementsValidatorSkipPlugin;
 
     public function __construct(
         MagentoPaymentInformationManagementInterface $paymentInformationManagement,
-        CartTotalRepositoryInterface $cartTotalRepository
+        CartTotalRepositoryInterface $cartTotalRepository,
+        AgreementsValidator $agreementsValidatorSkipPlugin
     ) {
         $this->paymentInformationManagement = $paymentInformationManagement;
         $this->cartTotalRepository = $cartTotalRepository;
+        $this->agreementsValidatorSkipPlugin = $agreementsValidatorSkipPlugin;
     }
 
     /**
@@ -36,6 +43,8 @@ class PaymentInformationManagement implements PaymentInformationManagementInterf
         PaymentInterface $paymentMethod,
         AddressInterface $billingAddress = null
     ): TotalsInterface {
+        $this->agreementsValidatorSkipPlugin->setIsSkipValidation(true);
+
         $this->paymentInformationManagement->savePaymentInformation(
             $cartId,
             $paymentMethod,

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types = 1);
+namespace Brandung\CashOnDeliveryFee\Setup;
+
+use Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee;
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        if (version_compare($context->getVersion(), '0.1.1', '<'))
+        {
+            foreach (['sales_invoice', 'sales_creditmemo'] as $entity)
+            {
+                foreach ([CashOnDeliveryFee::TOTAL_CODE => CashOnDeliveryFee::LABEL,
+                             CashOnDeliveryFee::BASE_TOTAL_CODE => CashOnDeliveryFee::BASE_LABEL] as $attributeCode => $attributeLabel)
+                {
+                    $setup->getConnection()->addColumn($setup->getTable($entity), $attributeCode, [
+                        'type' => Table::TYPE_DECIMAL,
+                        'length' => '12,4',
+                        'nullable' => false,
+                        'default' => (float)null,
+                        'comment' => $attributeLabel,
+                    ]);
+
+                }
+            }
+        }
+
+        $setup->endSetup();
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -5,7 +5,7 @@
         <section id="payment">
             <group id="cashondelivery">
                 <field id="fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Cash on Delivery Fee</label>
+                    <label>Cash On Delivery Fee</label>
                     <validate>validate-number</validate>
                 </field>
             </group>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -20,4 +20,9 @@
     <type name="Magento\Sales\Model\ResourceModel\Order\Collection">
         <plugin name="setCashOnDeliveryExtensionAfterLoad" type="Brandung\CashOnDeliveryFee\Plugin\Order\LoadCashOnDeliveryFeeOnCollection"/>
     </type>
+
+    <!-- Agreements in checkout fix -->
+    <type name="Magento\CheckoutAgreements\Model\AgreementsValidator">
+        <plugin name="skipAgreementsValidation" type="Brandung\CashOnDeliveryFee\Plugin\CheckoutAgreements\Model\AgreementsValidator" sortOrder="1" />
+    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -25,4 +25,9 @@
     <type name="Magento\CheckoutAgreements\Model\AgreementsValidator">
         <plugin name="skipAgreementsValidation" type="Brandung\CashOnDeliveryFee\Plugin\CheckoutAgreements\Model\AgreementsValidator" sortOrder="1" />
     </type>
+
+    <!-- Correct Max amount calculation -->
+    <type name="Magento\Payment\Model\Checks\TotalMinMax">
+        <plugin name="checkTotalMinMax" type="Brandung\CashOnDeliveryFee\Plugin\Payment\Model\ChecksTotalMinMax" sortOrder="1" />
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Brandung_CashOnDeliveryFee" setup_version="0.1.0">
+    <module name="Brandung_CashOnDeliveryFee" setup_version="0.1.1">
         <sequence>
             <module name="Magento_Quote"/>
             <module name="Magento_Store"/>

--- a/etc/pdf.xml
+++ b/etc/pdf.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Sales:etc/pdf_file.xsd">
+    <totals>
+        <total name="cash_on_delivery_fee">
+            <title translate="true">Cash On Delivery Fee</title>
+            <source_field>cash_on_delivery_fee</source_field>
+            <font_size>10</font_size>
+            <display_zero>false</display_zero>
+            <sort_order>280</sort_order>
+        </total>
+    </totals>
+</config>

--- a/etc/sales.xml
+++ b/etc/sales.xml
@@ -8,4 +8,18 @@
                   sort_order="99"/>
         </group>
     </section>
+    <section name="order_invoice">
+        <group name="totals">
+            <item name="cash_on_delivery_fee"
+                  instance="Brandung\CashOnDeliveryFee\Model\Total\Invoice\CashOnDeliveryFee"
+                  sort_order="160"/>
+        </group>
+    </section>
+    <section name="order_creditmemo">
+        <group name="totals">
+            <item name="cash_on_delivery_fee"
+                  instance="Brandung\CashOnDeliveryFee\Model\Total\Creditmemo\CashOnDeliveryFee"
+                  sort_order="160"/>
+        </group>
+    </section>
 </config>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -17,7 +17,7 @@
                                                             <item name="component"  xsi:type="string">Brandung_CashOnDeliveryFee/js/view/checkout/summary/cash-on-delivery-fee</item>
                                                             <item name="sortOrder" xsi:type="string">99</item>
                                                             <item name="config" xsi:type="array">
-                                                                <item name="title" xsi:type="string" translate="true">Cash on Delivery Fee</item>
+                                                                <item name="title" xsi:type="string" translate="true">Cash On Delivery Fee</item>
                                                             </item>
                                                         </item>
                                                     </item>


### PR DESCRIPTION
- #9: Fee is added to invoice and creditmemo
- #11: When saving the payment a plugin validates agreements which are always empty since t
- #14: Max order amount limit takes into consideration the fee
- Also fixes the translation string that has a typo
- Quote total collector is collected twice, it should only be once (when shipping assignment has items)