### PR TITLE
Add website support for Cash On Delivery Fee

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -4,7 +4,7 @@
     <system>
         <section id="payment">
             <group id="cashondelivery">
-                <field id="fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Cash On Delivery Fee</label>
                     <validate>validate-number</validate>
                 </field>


### PR DESCRIPTION
The fee will be most likely website specific, thus enable it.