### PR TITLE
Pull base currency from website and not global level

### DIFF
--- a/Model/Total/CashOnDeliveryFee.php
+++ b/Model/Total/CashOnDeliveryFee.php
@@ -33,7 +33,7 @@ class CashOnDeliveryFee extends AbstractTotal
     )
     {
         $this->fee = (float)$scopeConfig->getValue(static::CONFIG_PATH_FEE_AMOUNT, ScopeInterface::SCOPE_STORE);
-        $currencyCode = $scopeConfig->getValue("currency/options/base", ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
+        $currencyCode = $scopeConfig->getValue("currency/options/base", ScopeInterface::SCOPE_WEBSITES);
         $this->baseCurrency =  $currencyFactory->create()->load($currencyCode);
     }
 


### PR DESCRIPTION
Follwing the pull request #28 from @pevik to make the extension multistore-ready, the currency code needs to be pulled from the website level, not global level. 
If you have different base currencies on global and website level, a website specific base currency setting will be overwritten by the global level and the value converted to the checkout currency from the global level currency, not the website currency. 

This pull request fixes this issue and pulls the website level base currency.