### PR TITLE
Creditmemo: Invoice: CashOnDeliveryFee.php: Cast string to float

### DIFF
--- a/Model/Total/Creditmemo/CashOnDeliveryFee.php
+++ b/Model/Total/Creditmemo/CashOnDeliveryFee.php
@@ -12,7 +12,7 @@ class CashOnDeliveryFee extends \Magento\Sales\Model\Order\Creditmemo\Total\Abst
     {
         parent::collect($creditmemo);
 
-        $codFee = $creditmemo->getOrder()->getExtensionAttributes()->getCashOnDeliveryFee();
+        $codFee = (float)$creditmemo->getOrder()->getExtensionAttributes()->getCashOnDeliveryFee();
         $baseCodFee = $creditmemo->getOrder()->getExtensionAttributes()->getBaseCashOnDeliveryFee();
 
         $creditmemo->setData(\Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee::TOTAL_CODE, $codFee);

--- a/Model/Total/Invoice/CashOnDeliveryFee.php
+++ b/Model/Total/Invoice/CashOnDeliveryFee.php
@@ -12,7 +12,7 @@ class CashOnDeliveryFee extends \Magento\Sales\Model\Order\Invoice\Total\Abstrac
     {
         parent::collect($invoice);
 
-        $codFee = $invoice->getOrder()->getExtensionAttributes()->getCashOnDeliveryFee();
+        $codFee = (float)$invoice->getOrder()->getExtensionAttributes()->getCashOnDeliveryFee();
         $baseCodFee = $invoice->getOrder()->getExtensionAttributes()->getBaseCashOnDeliveryFee();
 
         $invoice->setData(\Brandung\CashOnDeliveryFee\Model\Total\CashOnDeliveryFee::TOTAL_CODE, $codFee);


### PR DESCRIPTION
This is required either by PHP8.1 or Magento 2.4.4.

Otherwise it fails:

```
TypeError: round(): Argument #1 ($num) must be of type int|float, string given in
/vendor/brandung/cash-on-delivery-fee/Model/Total/Invoice/CashOnDeliveryFee.php:21
```

Fixes: #38